### PR TITLE
Call canAddOutput before calling addOutput

### DIFF
--- a/Sources/Media/VideoIOComponent.swift
+++ b/Sources/Media/VideoIOComponent.swift
@@ -330,6 +330,10 @@ final class VideoIOComponent: IOComponent {
         #endif
 
         input = try AVCaptureDeviceInput(device: camera)
+        guard mixer.session.canAddOutput(output) else {
+            // NSErrorしか受けれないのでとりま
+            throw NSError()
+        }
         mixer.session.addOutput(output)
 
         for connection in output.connections {


### PR DESCRIPTION
canAddOutputを呼ばないとクラッシュする
NSErrorしか受けれないインタフェースなのでそれに合わせた